### PR TITLE
Replaced gameapp.GameApp with avgapp.AVGApp

### DIFF
--- a/geneatd/war.py
+++ b/geneatd/war.py
@@ -76,7 +76,7 @@ inActiveCreatureLayer = avg.DivNode(id="inActiveCreatureLayer", size=(util.width
 
 
 
-class GeneaTD(gameapp.GameApp):   
+class GeneaTD(avgapp.AVGApp):   
     """
     The main class.
     """


### PR DESCRIPTION
It seems the libavg 1.8 update removed the `gameapp.GameApp`, which breaks GeneaTD.

This update should fix this by changing the base class of `GeneaTD` to `avgapp.AVGApp`.

I did not do any extensive testing but start-up seems to work fine with this change.
